### PR TITLE
Fix: team details screen

### DIFF
--- a/docs/contributorsGreatAndSmall.md
+++ b/docs/contributorsGreatAndSmall.md
@@ -42,5 +42,7 @@ a pat on the back if you see them.
 * Tito Ortiz
 * Charles Davidson
 * Shariq Ali
+* Stuart Hunt
+* Eugene Yum
 
 (I know we do not have the names of the original students who worked on this)

--- a/screens/team-details-screen/index.js
+++ b/screens/team-details-screen/index.js
@@ -331,7 +331,7 @@ const TeamDetailsScreen = ({ actions, currentUser, invitations, navigation, sele
                     </Text>
                     <Text style={ styles.dataBlock }>
                         <Text style={ styles.text }>{ "Starts: " }</Text>
-                        <Text style={ styles.text }>{ selectedTeam.start }</Text>
+                        <Text style={ styles.text }>{ selectedTeam.startdate }</Text>
                     </Text>
                     <Text style={ styles.dataBlock }>
                         <Text style={ styles.text }>{ "Ends: " }</Text>


### PR DESCRIPTION
Fix to display start dates on the team details screen.