### PR TITLE
Fix: invite contacts

### DIFF
--- a/action-creators/team-action-creators.js
+++ b/action-creators/team-action-creators.js
@@ -58,8 +58,8 @@ export const inviteContacts = (team: Object, currentUser: Object, teamMembers: [
             return firebaseDataLayer.inviteTeamMember(invitation);
         });
         Promise.all(invites)
-            .then((data: Array<any>) => {
-                dispatch({ type: types.SEND_INVITATIONS_SUCCESS, data });
+            .then(() => {
+                dispatch({ type: types.SEND_INVITATIONS_SUCCESS, data: { teamId: team.id, invitedMembers: teamMembers } });
             })
             .catch(error => {
                 dispatch({ type: types.SEND_INVITATIONS_FAIL, error });

--- a/data-sources/firebase-data-layer.js
+++ b/data-sources/firebase-data-layer.js
@@ -161,9 +161,6 @@ const setupInvitedTeamMemberListener = (teamIds: Array<string>, dispatch: Dispat
     const teamRef = doc(firestore, `teams/${teamId}`)
     const ref = collection(teamRef, `invitations`);
 
-    const listener = onSnapshot(ref, { next: onSnapshotz, error: onError })
-
-
     const onSnapshotz = (querySnapshot: Object) => {
         const data = [];
         querySnapshot.forEach((_doc: Object) => {
@@ -178,6 +175,7 @@ const setupInvitedTeamMemberListener = (teamIds: Array<string>, dispatch: Dispat
         // TODO : Handle the error
     });
 
+    const listener = onSnapshot(ref, onSnapshotz, onError);
     addListener(`teamMembers_${ teamId }_invitations`, listener);
     // const ref = db.collection(`teams/${ teamId }/invitations`);
 

--- a/reducers/teams-reducers.js
+++ b/reducers/teams-reducers.js
@@ -58,6 +58,30 @@ export const teamsReducers = (state: Object = initialState.teams, action: Action
                 teamMembersLoaded: true
             };
         }
+        case types.SEND_INVITATIONS_SUCCESS : {
+            const teamId = (action.data || {}).teamId;
+            const invitedMembers = (action.data || {}).invitedMembers || [];
+            if (!teamId) return state;
+
+            const newMembers = {};
+            for (const member of invitedMembers) {
+                const key = member.uid || member.email;
+                if (key) {
+                    newMembers[key] = member;
+                }
+            }
+
+            return {
+                ...state,
+                teamMembers: {
+                    ...state.teamMembers,
+                    [teamId]: {
+                        ...(state.teamMembers[teamId] || {}),
+                        ...newMembers
+                    }
+                }
+            };
+        }
         case types.TEAM_REQUEST_FETCH_SUCCESS : {
             return {
                 ...state,

--- a/screens/team-details-screen/index.js
+++ b/screens/team-details-screen/index.js
@@ -444,7 +444,13 @@ const mapStateToProps = (state: Object): Object => {
         .values((state.towns.townData || {}))
         .find((_town: Object): boolean => (_town.name || "").toLowerCase() === selectedTownName);
     const selectedTeam = state.teams.selectedTeam || {};
-    const teamMembers = state.teams.teamMembers[selectedTeam.id] || {};
+    
+    // Combine members, requests, and invitations into one block for the list
+    const members = state.teams.teamMembers[selectedTeam.id] || {};
+    const requests = (state.teams.teamRequests || {})[selectedTeam.id] || {};
+    const teamInvitations = (state.teams.invitations || {})[selectedTeam.id] || {};
+    const teamMembers = { ...requests, ...teamInvitations, ...members };
+    
     const currentUser = User.create({ ...state.login.user, ...state.profile });
     const invitations = state.teams.myInvitations || {};
     return ({


### PR DESCRIPTION
This request proposes changes to support invited team members displaying on screens:
* Team reducers handles the case when `SEND_INVITATIONS_SUCCESS` is dispatched
* The team details screen groups members, requests, and invitations for display
* [Declare listener after onSnapshotz callback has been defined](https://github.com/codeforbtv/green-up-app/pull/4/changes/cf5b178691046cf9c69864cc5c470efe3a5a5252) in setupInvitedTeamMemberListener