### PR TITLE
bugfix: messages tab crash for users with no teams or messages

### DIFF
--- a/screens/message-summaries-screen/index.js
+++ b/screens/message-summaries-screen/index.js
@@ -18,6 +18,7 @@ import * as R from "ramda";
 import * as constants from "../../styles/constants";
 import { SimpleLineIcons } from "@expo/vector-icons";
 import ButtonBar from "../../components/button-bar";
+import { PrimaryButton, SecondaryButton } from "@/components/button";
 import { FlatList } from "react-native";
 import colors from "@/constants/colors";
 
@@ -217,22 +218,20 @@ const MessageSummariesScreen = ({ actions, currentUser, messages, navigation, us
                                 { "To send messages, join or create a team." }
                             </Text>
                         </View>
-                        <View styleName="horizontal" style={ { marginTop: 30 } }>
-                            <Button
+                        <View style={ { flexDirection: "row", marginTop: 30 } }>
+                            <PrimaryButton
                                 onPress={ () => {
                                     navigation.navigate("FindTeam");
-                                } }
-                                styleName="confirmation">
-                                <Text>JOIN A TEAM</Text>
-                            </Button>
+                                } }>
+                                <Text style={ { color: "white" } }>JOIN A TEAM</Text>
+                            </PrimaryButton>
 
-                            <Button
+                            <SecondaryButton
                                 onPress={ () => {
                                     navigation.navigate("NewTeam");
-                                } }
-                                styleName="confirmation secondary">
-                                <Text>CREATE A TEAM</Text>
-                            </Button>
+                                } }>
+                                <Text style={ { color: "white" } }>CREATE A TEAM</Text>
+                            </SecondaryButton>
                         </View>
                     </View>
                 )

--- a/screens/message-summaries-screen/index.js
+++ b/screens/message-summaries-screen/index.js
@@ -220,13 +220,15 @@ const MessageSummariesScreen = ({ actions, currentUser, messages, navigation, us
                         </View>
                         <View style={ { flexDirection: "row", marginTop: 30 } }>
                             <PrimaryButton
+                                style={ { width: "50%" } }
                                 onPress={ () => {
                                     navigation.navigate("FindTeam");
                                 } }>
-                                <Text style={ { color: "white" } }>JOIN A TEAM</Text>
+                                <Text style={ { color: "#555" } }>JOIN A TEAM</Text>
                             </PrimaryButton>
 
                             <SecondaryButton
+                                style={ { width: "50%" } }
                                 onPress={ () => {
                                     navigation.navigate("NewTeam");
                                 } }>


### PR DESCRIPTION
When [porting the dashboard](https://github.com/codeforbtv/greenup-dashboard/pull/2) to the new Firebase store, I created a mock user with no teams or messages. I used that same user to log into the app. I then clicked the Messages tab.

<img width="488" height="264" alt="image" src="https://github.com/user-attachments/assets/45b7e7d2-8455-47fd-acf9-d7d8e8e6fdff" />
<img width="532" height="1054" alt="image" src="https://github.com/user-attachments/assets/29cdb6ba-f0c1-4501-8d18-94044de25867" />

and got the error `ReferenceError: Property 'Button' doesn't exist` at `screens/message-summaries-screen/index.js:223`. **Reproduces for any logged-in user with zero teams *and* zero messages.**

Commit 5d77bd1d ("Remove shoutem from message summaries", Mar 2024) migrated this screen off shoutem-ui but missed the `!userHasTeams && messages.length === 0` branch, which still used `<Button styleName="confirmation">`.

## Fix

Replaced the two leftover  `<Button>`s with the project's own `PrimaryButton` / `SecondaryButton` (same pair `new-team-screen` uses). Swap `styleName="horizontal"` for `style={{ flexDirection: "row" }}`.